### PR TITLE
Expanded coordinates for neighborhoods

### DIFF
--- a/app/components/index/MainMap.tsx
+++ b/app/components/index/MainMap.tsx
@@ -10,6 +10,9 @@ type MainMapProps = {
 
 const MainMap: React.FC<MainMapProps> = ({ neighborhoodString }) => {
 
+  console.log(neighborhoodString);
+  console.log(mapboxNeighborhood[neighborhoodString]);
+
   return <div className='w-full h-full'>
     <Map
       mapboxAccessToken={process.env.NEXT_PUBLIC_MAPBOX_API_KEY}

--- a/app/js/setting.tsx
+++ b/app/js/setting.tsx
@@ -45,8 +45,8 @@ export const citiesNeighborhoods : DoubleMap = {
         "universityDistrict": "University District",
     },
     'kelowna': {
-        'ubco': 'UBCO',
         'downtown': 'Downtown',
+        'ubco': 'UBCO',
     }
 };
 
@@ -54,6 +54,22 @@ export const mapboxNeighborhood: coordinates = {
     "queenAnne": {
         longitude: -122.359749,
         latitude: 47.639396,
+        zoom: 13,
+    },
+    "universityDistrict": {
+        longitude: 47.657439,
+        latitude : -122.307052,
+        zoom: 13,
+    },
+
+    "ubco" : {
+        longitude: -119.3948, 
+        latitude: 49.9407,
+        zoom: 15.5,
+    },
+    "downtown": {
+        longitude : -119.49382440053064, 
+        latitude: 49.88780463790179,
         zoom: 13,
     }
 }


### PR DESCRIPTION
I added coordinate values for the University District, UBCO, and downtown Kelowna. in the citiesNeighborhoods const, for the 'kelowna' value,  I swapped 'downtown' and 'ubco' so that downtown Kelowna shows by default when Kelowna is selected as the city.